### PR TITLE
[breaking] this allows you to override fetch configs and does modular ramda

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -95,7 +95,7 @@ export class Client {
   public destroy = (endpoint: Endpoint): Promise<any> =>
     this.authorize(request(this.url(endpoint), null, { method: 'DESTROY', ...this.fetchConfig }))
 
-  private url = ({ base, action, params, qs }: Endpoint): string => compose(
+  private url = ({ base, action, params = {}, qs }: Endpoint): string => compose(
     when(
       () => notNil(qs),
       finalUrl => `${finalUrl}?${stringify(qs)}`

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -1,7 +1,12 @@
 import 'isomorphic-fetch'
 import { stringify } from 'qs'
 import * as S from 'string'
-import { when, not, isNil, compose, ifElse, identity } from 'ramda'
+import * as when from 'ramda/src/when'
+import * as not from 'ramda/src/not'
+import * as isNil from 'ramda/src/isNil'
+import * as compose from 'ramda/src/compose'
+import * as ifElse from 'ramda/src/ifElse'
+import * as identity from 'ramda/src/identity'
 import { Authorizer } from './interfaces'
 import hostname from './hostname'
 

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -72,15 +72,11 @@ function request(url: string, payload: any, config: RequestInit): Function {
 export class Client {
   private readonly host: string;
   private authorize: any;
-  private fetchConfig: RequestInit = {};
 
-  constructor(authorizer: Authorizer, host: string = hostname) {
+  constructor(authorizer: Authorizer, config: RequestInit = {}, host: string = hostname) {
     this.authorize = authorizer.authorize
     this.host = host
-  }
-
-  public configureFetch = (config: RequestInit) => {
-    this.fetchConfig = config
+    this.fetchConfig = config;
   }
 
   public get = (endpoint: Endpoint): Promise<any> =>

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -72,6 +72,7 @@ function request(url: string, payload: any, config: RequestInit): Function {
 export class Client {
   private readonly host: string;
   private authorize: any;
+  private fetchConfig: RequestInit;
 
   constructor(authorizer: Authorizer, config: RequestInit = {}, host: string = hostname) {
     this.authorize = authorizer.authorize

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -35,14 +35,14 @@ function authValid(response): any {
   }
 }
 
-function request(url: string, payload: any, method: string): Function {
+function request(url: string, payload: any, config: RequestInit): Function {
   const headers = new Headers()
   headers.append('Accept', 'application/json')
   headers.append('Content-Type', 'application/json')
 
-  let opts: RequestInit = { mode: 'cors', credentials: 'include', method, headers }
+  let opts: RequestInit = { mode: 'cors', credentials: 'include', headers, ...config }
 
-  if ((method !== 'GET' && method !== 'HEAD') && payload) {
+  if ((config.method !== 'GET' && config.method !== 'HEAD') && payload) {
     opts.body = JSON.stringify(payload)
   }
 
@@ -67,23 +67,28 @@ function request(url: string, payload: any, method: string): Function {
 export class Client {
   private readonly host: string;
   private authorize: any;
+  private overrideConfig: RequestInit = {};
 
   constructor(authorizer: Authorizer, host: string = hostname) {
     this.authorize = authorizer.authorize
     this.host = host
   }
 
+  public configure = (config: RequestInit) => {
+    this.overrideConfig = config
+  }
+
   public get = (endpoint: Endpoint): Promise<any> =>
-    this.authorize(request(this.url(endpoint), null, 'GET'))
+    this.authorize(request(this.url(endpoint), null, { method: 'GET', ...this.overrideConfig }))
 
   public post = (endpoint: Endpoint, payload: any): Promise<any> =>
-    this.authorize(request(this.url(endpoint), payload, 'POST'))
+    this.authorize(request(this.url(endpoint), payload, { method: 'POST', ...this.overrideConfig }))
 
   public patch = (endpoint: Endpoint, payload: any): Promise<any> =>
-    this.authorize(request(this.url(endpoint), payload, 'PATCH'))
+    this.authorize(request(this.url(endpoint), payload, { method: 'PATCH', ...this.overrideConfig }))
 
   public destroy = (endpoint: Endpoint): Promise<any> =>
-    this.authorize(request(this.url(endpoint), null, 'DESTROY'))
+    this.authorize(request(this.url(endpoint), null, { method: 'DESTROY', ...this.overrideConfig }))
 
   private url = ({ base, action, params, qs }: Endpoint): string => compose(
     when(

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -77,7 +77,7 @@ export class Client {
   constructor(authorizer: Authorizer, config: RequestInit = {}, host: string = hostname) {
     this.authorize = authorizer.authorize
     this.host = host
-    this.fetchConfig = config;
+    this.fetchConfig = config
   }
 
   public get = (endpoint: Endpoint): Promise<any> =>
@@ -110,8 +110,8 @@ export class Client {
 
 }
 
-function client(authorizer: Authorizer, host: string = hostname) {
-  return new Client(authorizer, host)
+function client(authorizer: Authorizer, config: RequestInit = {}, host: string = hostname) {
+  return new Client(authorizer, config, host)
 }
 
 export default client

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -67,28 +67,28 @@ function request(url: string, payload: any, config: RequestInit): Function {
 export class Client {
   private readonly host: string;
   private authorize: any;
-  private overrideConfig: RequestInit = {};
+  private fetchConfig: RequestInit = {};
 
   constructor(authorizer: Authorizer, host: string = hostname) {
     this.authorize = authorizer.authorize
     this.host = host
   }
 
-  public configure = (config: RequestInit) => {
-    this.overrideConfig = config
+  public configureFetch = (config: RequestInit) => {
+    this.fetchConfig = config
   }
 
   public get = (endpoint: Endpoint): Promise<any> =>
-    this.authorize(request(this.url(endpoint), null, { method: 'GET', ...this.overrideConfig }))
+    this.authorize(request(this.url(endpoint), null, { method: 'GET', ...this.fetchConfig }))
 
   public post = (endpoint: Endpoint, payload: any): Promise<any> =>
-    this.authorize(request(this.url(endpoint), payload, { method: 'POST', ...this.overrideConfig }))
+    this.authorize(request(this.url(endpoint), payload, { method: 'POST', ...this.fetchConfig }))
 
   public patch = (endpoint: Endpoint, payload: any): Promise<any> =>
-    this.authorize(request(this.url(endpoint), payload, { method: 'PATCH', ...this.overrideConfig }))
+    this.authorize(request(this.url(endpoint), payload, { method: 'PATCH', ...this.fetchConfig }))
 
   public destroy = (endpoint: Endpoint): Promise<any> =>
-    this.authorize(request(this.url(endpoint), null, { method: 'DESTROY', ...this.overrideConfig }))
+    this.authorize(request(this.url(endpoint), null, { method: 'DESTROY', ...this.fetchConfig }))
 
   private url = ({ base, action, params, qs }: Endpoint): string => compose(
     when(

--- a/lib/oauth.ts
+++ b/lib/oauth.ts
@@ -1,5 +1,5 @@
 import * as fetch from 'isomorphic-fetch'
-import { isNil } from 'ramda'
+import isNil from 'ramda/src/isNil'
 import token from './token'
 import { Authorizer } from './interfaces'
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@types/chai": "^3.4.34",
     "@types/core-js": "^0.9.35",
     "@types/fetch-mock": "^5.8.0",
+    "@types/isomorphic-fetch": "^0.0.34",
     "@types/mocha": "^2.2.38",
     "@types/qs": "^6.2.30",
     "@types/ramda": "^0.0.3",

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -15,8 +15,23 @@ const headers = { 'Authorization': `Bearer ${token}` }
 
 describe('client', () => {
   context('using oauth', () => {
-    describe('#post', () => {
+    describe('request defaults', () => {
+      it('sets default request options', (done) => {
+        const authorizer = oauth(token)
 
+        const procore = client(authorizer, { credentials: 'omit' })
+
+        fetchMock.get(`end:test_config`, {})
+
+        procore
+          .get({ base: '/test_config' })
+          .then(({ response, request }) => {
+            done()
+          })
+      })
+    })
+
+    describe('#post', () => {
       const authorizer = oauth(token)
 
       const procore = client(authorizer)

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,10 @@
   version "9.1.9"
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.9.tgz#ed6336955eaf233b75eb7923b9b1f373d045ef01"
 
+"@types/isomorphic-fetch@^0.0.34":
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.34.tgz#3c3483e606c041378438e951464f00e4e60706d6"
+
 "@types/lodash@^4.14.37":
   version "4.14.52"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.52.tgz#de5c7ab14da1289733233c9b0ec6f9e377db90f5"
@@ -544,9 +548,9 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-"progress@git+https://github.com/visionmedia/node-progress.git":
-  version "1.1.8"
-  resolved "git+https://github.com/visionmedia/node-progress.git#191256e02ec20c89b2e2834e25d17c3a7257d18a"
+"progress@https://github.com/visionmedia/node-progress":
+  version "2.0.0"
+  resolved "https://github.com/visionmedia/node-progress#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
 
 qs@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
#### Summary 
if you `fetch` with `credentials: 'include', mode: 'cors'` the browser expects to see a `Access-Control-Allow-Credentials` response header. we dont have that set on procore, but can send our credentials through the `Authorization` header. this pr allows us to configure via

```
this.procore = client(oauth(accessToken), OAUTH_BASE_URL);
this.procore.configure({ mode: 'cors', credentials: 'omit' });
```

<img width="1559" alt="screenshot 2017-06-29 14 17 01" src="https://user-images.githubusercontent.com/1206074/27711280-8b330dd0-5cd7-11e7-8968-520816da4ebc.png">

#### Other
This PR also changes to modular ramda imports which takes the bundle size from ~ 360kb to ~90kb

##### Before
<img width="779" alt="screenshot 2017-06-30 10 58 50" src="https://user-images.githubusercontent.com/1206074/27748256-935122fc-5d83-11e7-91a5-6316c59d8ab6.png">

##### After
<img width="630" alt="screenshot 2017-06-30 11 00 49" src="https://user-images.githubusercontent.com/1206074/27748209-664aab7a-5d83-11e7-9c9e-3998589f52de.png">