### PR TITLE
Support string as endpoint passed to client http methods

### DIFF
--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -91,6 +91,22 @@ describe('client', () => {
               done()
             })
         })
+
+        context('using a string url as the endpoint', () => {
+          it('gets a signleton resource', (done) => {
+            fetchMock.get('end:vapid/me', me)
+
+            procore
+              .get('/vapid/me')
+              .then(({ body }) => {
+                expect(body).to.eql(me)
+
+                fetchMock.restore()
+
+                done()
+              })
+          })
+        })
       })
 
       describe('by id', () => {


### PR DESCRIPTION
### Changes
- Endpoints can now me strings or config object