### PR TITLE
feat: Non-Ok responses return a rejected Promise with a structure matching Ok responses

### DIFF
--- a/lib/client.ts
+++ b/lib/client.ts
@@ -36,14 +36,6 @@ const notNil = compose(
   isNil
 )
 
-function authValid(response): any {
-  if (response.status === 403 || response.status === 401 || !response.ok) {
-    throw new Error(`${response.status} ${response.statusText}`)
-  } else {
-   return response
-  }
-}
-
 const baseRequest = (defaults: RequestInit): Function => (url: string, config: RequestInit): Function => {
   const headers = new Headers()
   headers.append('Accept', 'application/json')
@@ -61,19 +53,15 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
     const request = fetch(url, opts)
 
     return request
-      .then(authValid)
-      .then((response) => new Promise((res, rej) => {
-        if (response.status === 204) {
-          return res({ body: {}, request, response });
-        }
-
+      .then((response) => {
         return response
           .json()
-          .then((body) => {
-            res({ body, request, response })
-          })
-          .catch(rej);
-      }))
+          .then((body) => new Promise((res, rej) => {
+            const sdkResp = {body, request, response}
+
+            response.ok ? res(sdkResp) : rej(sdkResp)
+          }))
+      })
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "A wrapper for the procore API",
   "main": "lib",
   "homepage": "https://github.com/procore/js-sdk",

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -55,6 +55,25 @@ describe('client', () => {
             done()
           })
       })
+
+      it('returns the raw request even if the request fails', done => {
+        const procore = client(oauth(token))
+        const response = {
+          status: 401,
+          body: {errors: {name: ['is already taken']}}
+        }
+
+        fetchMock.get('end:test_config', response)
+
+        procore.get({base: '/test_config'})
+          .catch(({body, response: {status}}) => {
+            expect(body).to.eql(response.body)
+            expect(status).to.eql(response.status)
+
+            fetchMock.restore()
+            done()
+          })
+      })
     })
 
     describe('#post', () => {


### PR DESCRIPTION
BREAKING CHANGE
Essentially, if an endpoint returned a 400(as it should for validation errors), we
would lose the response, and not be able to parse said errors. This changes it to
match what would be the format for a successful response, but keeps it as
an error response to match assumed intention of previous code.