### PR TITLE
Upgrade js-sdk-endpoints for a dependency fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Procore Tech <insights@procore.com> (http://procore.com)",
   "license": "ISC",
   "dependencies": {
-    "@procore/js-sdk-endpoints": "^1.9.0",
+    "@procore/js-sdk-endpoints": "1.9.1",
     "isomorphic-fetch": "^2.2.1",
     "qs": "^6.3.0",
     "ramda": "^0.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A wrapper for the procore API",
   "main": "lib",
   "homepage": "https://github.com/procore/js-sdk",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,16 @@
 # yarn lockfile v1
 
 
-"@procore/js-sdk-endpoints@^1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.0.tgz#0d060ef2f89ad475e706c787595f085f1fc68913"
+"@procore/js-sdk-endpoints@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.1.tgz#09e489849086a93af49f26cb476f8ec2e4c9eb62"
+  integrity sha512-tvjzdjkUd3s3CBSztTOjGh0VAES/ZthyxLKI4cjNqXAI8Zdn84fI31gmY9hsq5Pu4Ie6dr/PmvU06q/BA4Rghw==
   dependencies:
     chalk "^1.1.3"
     commander "^2.9.0"
     handlebars "^4.0.6"
     isomorphic-fetch "^2.2.1"
-    progress "https://github.com/visionmedia/node-progress"
+    progress "^2.0.0"
     ramda "^0.23.0"
     string "^3.3.3"
     to-pascal-case "^1.0.0"
@@ -533,9 +534,10 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-"progress@https://github.com/visionmedia/node-progress":
-  version "2.0.0"
-  resolved "https://github.com/visionmedia/node-progress#30d70d968c4a39b44282cc70c42a026cd8f86fcc"
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 qs@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
Need to upgrade `@procore/js-sdk-endpoints` to fix a dependency bug that potentially caused the [CI to fail](https://app.circleci.com/pipelines/github/procore/procore/165474/workflows/f1a988c3-1485-44c3-9e02-857d7f3d7e37/jobs/2245933).  
More details in https://github.com/procore/js-sdk-endpoints/pull/6