### PR TITLE
add formatter per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,20 @@ A single API response contains the response body (JSON parsed), original request
     });
 ```
 
+### Formatting the response
+
+By default, the SDK tries to format the response as JSON, you can control the
+response formatting passing the `formatter` option as follow:
+
+```tsx
+// Create your own formatter
+function formatter(response: Response): Promise<unknown> {
+  return response.text()
+}
+
+// Pass the formatter configuration
+procore.get(myendpoint(), { formatter })
+```
 
 ## Tests
 ```

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -85,16 +85,16 @@ export class Client {
   }
 
   public get = (endpoint: Endpoint, reqConfig?: RequestConfig): Promise<any> =>
-    this.authorize(this.request(this.url(endpoint), { method: 'GET' }))
+    this.authorize(this.request(this.url(endpoint), { method: 'GET' }, reqConfig))
 
   public post = (endpoint: Endpoint, payload: any, reqConfig?: RequestConfig): Promise<any> =>
-    this.authorize(this.request(this.url(endpoint), { method: 'POST' , body: JSON.stringify(payload)}))
+    this.authorize(this.request(this.url(endpoint), { method: 'POST' , body: JSON.stringify(payload)}, reqConfig))
 
   public patch = (endpoint: Endpoint, payload: any, reqConfig?: RequestConfig): Promise<any> =>
-    this.authorize(this.request(this.url(endpoint), { method: 'PATCH', body: JSON.stringify(payload)}))
+    this.authorize(this.request(this.url(endpoint), { method: 'PATCH', body: JSON.stringify(payload)}, reqConfig))
 
   public destroy = (endpoint: Endpoint, payload?: any, reqConfig?: RequestConfig): Promise<any> =>
-    this.authorize(this.request(this.url(endpoint), { method: 'DELETE', body: JSON.stringify(payload)}))
+    this.authorize(this.request(this.url(endpoint), { method: 'DELETE', body: JSON.stringify(payload)}, reqConfig))
 
   private url = (endpoint: Endpoint): string => ifElse(
     is(String),

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -36,7 +36,11 @@ const notNil = compose(
   isNil
 )
 
-const baseRequest = (defaults: RequestInit): Function => (url: string, config: RequestInit): Function => {
+function defaultFormatter(response: Response) {
+  return response.json();
+}
+
+const baseRequest = (defaults: RequestInit): Function => (url: string, config: RequestInit, reqConfig?: RequestConfig): Function => {
   const headers = new Headers()
   headers.append('Accept', 'application/json')
   headers.append('Content-Type', 'application/json')
@@ -51,11 +55,11 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
     }
 
     const request = fetch(url, opts)
+    const formatter = reqConfig && reqConfig.formatter ? reqConfig.formatter : defaultFormatter;
 
     return request
       .then((response) => {
-        return response
-          .json()
+        return formatter(response)
           .then((body) => new Promise((res, rej) => {
             const sdkResp = {body, request, response}
 
@@ -63,6 +67,10 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
           }))
       })
   }
+}
+
+interface RequestConfig {
+  formatter?(response: Response): Promise<any>;
 }
 
 export class Client {
@@ -76,16 +84,16 @@ export class Client {
     this.request = baseRequest(config)
   }
 
-  public get = (endpoint: Endpoint): Promise<any> =>
+  public get = (endpoint: Endpoint, reqConfig?: RequestConfig): Promise<any> =>
     this.authorize(this.request(this.url(endpoint), { method: 'GET' }))
 
-  public post = (endpoint: Endpoint, payload: any): Promise<any> =>
+  public post = (endpoint: Endpoint, payload: any, reqConfig?: RequestConfig): Promise<any> =>
     this.authorize(this.request(this.url(endpoint), { method: 'POST' , body: JSON.stringify(payload)}))
 
-  public patch = (endpoint: Endpoint, payload: any): Promise<any> =>
+  public patch = (endpoint: Endpoint, payload: any, reqConfig?: RequestConfig): Promise<any> =>
     this.authorize(this.request(this.url(endpoint), { method: 'PATCH', body: JSON.stringify(payload)}))
 
-  public destroy = (endpoint: Endpoint, payload?: any): Promise<any> =>
+  public destroy = (endpoint: Endpoint, payload?: any, reqConfig?: RequestConfig): Promise<any> =>
     this.authorize(this.request(this.url(endpoint), { method: 'DELETE', body: JSON.stringify(payload)}))
 
   private url = (endpoint: Endpoint): string => ifElse(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A wrapper for the procore API",
   "main": "lib",
   "homepage": "https://github.com/procore/js-sdk",

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -2,7 +2,6 @@ import * as fetchMock from 'fetch-mock'
 import { stringify } from 'qs'
 import { expect } from 'chai'
 import { client, oauth, implicit } from './../lib'
-import { count } from "core-js/fn/log"
 
 const project = { id: 3 }
 

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -2,6 +2,7 @@ import * as fetchMock from 'fetch-mock'
 import { stringify } from 'qs'
 import { expect } from 'chai'
 import { client, oauth, implicit } from './../lib'
+import { count } from "core-js/fn/log"
 
 const project = { id: 3 }
 
@@ -14,6 +15,27 @@ const token = "token"
 const headers = { 'Authorization': `Bearer ${token}` }
 
 describe('client', () => {
+  it('uses the custom formatter', (done) => {
+    const authorizer = oauth(token)
+    const procore = client(authorizer)
+    let counter = 1;
+
+    function formatter(response: any) {
+      counter +=1;
+      return response.json();
+    }
+
+    fetchMock.get('end:vapid/me', me)
+    procore
+      .get('/vapid/me', { formatter })
+      .then(({ body }) => {
+        expect(body).to.eql(me)
+        expect(counter).to.eql(2)
+        fetchMock.restore()
+        done()
+      })
+  })
+
   context('using oauth', () => {
     describe('request defaults', () => {
       it('sets default request options', (done) => {


### PR DESCRIPTION
fixes #34

## Usage

```tsx
// plain text for CVS responses, or you could parse the response with some library
function formatter(response) {
  return response.text()
}
 
procore.get(myCSVEndpoint(), { formatter }),
```