### PR TITLE
Dependency Update js-sdk-endpoints 1.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+## 2.4.1
+- deps: `"@procore/js-sdk-endpoints": "1.9.2"` adds types from fixing bad URL generation

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ yarn test
 
 ## Endpoint Generator
 
-[`node-procore-endpoints`](https://github.com/procore/js-sdk-endpoints) generates interfaces and endpoint functions for improved developer experience. See the project for more details.
+[`js-sdk-endpoints`](https://github.com/procore/js-sdk-endpoints) generates interfaces and endpoint functions for improved developer experience. See the project for more details.
 
 ```typescript
 interface DirectCosts {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A wrapper for the procore API",
   "main": "lib",
   "homepage": "https://github.com/procore/js-sdk",
@@ -19,7 +19,7 @@
   "author": "Procore Tech <insights@procore.com> (http://procore.com)",
   "license": "ISC",
   "dependencies": {
-    "@procore/js-sdk-endpoints": "1.9.1",
+    "@procore/js-sdk-endpoints": "1.9.2",
     "isomorphic-fetch": "^2.2.1",
     "qs": "^6.3.0",
     "ramda": "^0.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@procore/js-sdk-endpoints@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.1.tgz#09e489849086a93af49f26cb476f8ec2e4c9eb62"
-  integrity sha512-tvjzdjkUd3s3CBSztTOjGh0VAES/ZthyxLKI4cjNqXAI8Zdn84fI31gmY9hsq5Pu4Ie6dr/PmvU06q/BA4Rghw==
+"@procore/js-sdk-endpoints@1.9.2":
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/@procore/js-sdk-endpoints/-/js-sdk-endpoints-1.9.2.tgz#e2193ab2d4eba55324124c5ef61715d7a08e6cdc"
+  integrity sha512-VuztLYg6kHrLeNU3LnEg5vlimx9Lvgrbo0clvEiqEVG6saSXcFtph1U9eyXNkxa/iYz+s/TrK2SWZvmkz+PTLQ==
   dependencies:
     chalk "^1.1.3"
     commander "^2.9.0"


### PR DESCRIPTION
Related https://github.com/procore/js-sdk-endpoints/issues/9

Use new version of js-sdk-endpoints which will now add the types and functions for endpoints that failed to fetch their URL