### PR TITLE
Adds decodeURIComponent and tests to csrf module

### DIFF
--- a/lib/csrf.ts
+++ b/lib/csrf.ts
@@ -1,18 +1,26 @@
 import { Authorizer } from './interfaces'
 
 class Csrf implements Authorizer {
+  public getToken: Function;
+  public csrfHeader: String;
+
+  constructor(csrfHeader?: String, getToken?: Function) {
+    this.getToken = getToken || Csrf.getTokenFromCookie
+    this.csrfHeader = csrfHeader || 'X-CSRF-TOKEN'
+  }
+
   public authorize(request: Function): Promise<any> {
-    return request(['X-CSRF-TOKEN', getTokenFromCookie()])
+    return request([this.csrfHeader, this.getToken()])
+  }
+
+  private static getTokenFromCookie(): String {
+    var token = document.cookie.match('(^|;)\\s*csrf_token\\s*=\\s*([^;]+)');
+    return token ? decodeURIComponent(token.pop()) : '';
   }
 }
 
-function csrf(): Csrf {
-  return new Csrf()
-}
-
-function getTokenFromCookie() {
-  var token = document.cookie.match('(^|;)\\s*csrf_token\\s*=\\s*([^;]+)');
-  return token ? token.pop() : '';
+function csrf(csrfHeader?: String, getToken?: Function ): Csrf {
+  return new Csrf(csrfHeader, getToken)
 }
 
 export default csrf

--- a/test/csrf.spec.ts
+++ b/test/csrf.spec.ts
@@ -1,0 +1,18 @@
+import { spy } from 'sinon'
+import { csrf } from '../lib/index'
+import { expect } from 'chai'
+
+describe('csrf', () => {
+
+  describe('#authorize', () => {
+    it('provides token header for the request', () => {
+      const getToken = () => 'fake_token';
+      const authorizer = csrf('X-CSRF-TOKEN', getToken);
+      const request = spy()
+
+      authorizer.authorize(request)
+      
+      expect(request.calledWith(['X-CSRF-TOKEN', 'fake_token'])).to.eql(true)
+    })
+  })
+})


### PR DESCRIPTION
Adds decodeURIComponent to the getTokenFromCookie function.
Adds test spec for the csrf module.
Adds optional parameters to the csrf module for specifying custom csrf header name and custom token fetching function.
Changes getTokenFromCookie to a private member Csrf function.