### PR TITLE
Feat(MPZ) - add support with custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ function formatter(response) {
 procore.get({base: '/me'}, { formatter })
 ```
 
+### Handling Multiple Procore Zones (MPZ)
+
+You can also add custom headers to the request. A typical use case would be to add support for
+[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers)
+
+```javascript
+const procore = client(authorizer);
+// Create your own headers
+const headers = {
+  'Procore-Company-Id': procoreCompanyId,
+};
+
+// Pass the headers configuration
+procore.get({base: '/projects', qs: {company_id: procoreCompanyId}, { headers })
+```
+
 ## Tests
 ```
 yarn && yarn test

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -51,7 +51,19 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
       opts.headers[authKey] = authValue;
     }
 
-    const formatter = reqConfig && reqConfig.formatter ? reqConfig.formatter : defaultFormatter;
+    // Add custom headers if provided in RequestConfig
+    if (reqConfig && reqConfig.headers) {
+      Object.keys(reqConfig.headers).forEach((key) => {
+        if (opts.headers instanceof Headers) {
+          opts.headers.set(key, reqConfig.headers[key]);
+        } else {
+          opts.headers[key] = reqConfig.headers[key];
+        }
+      });
+    }
+
+    const formatter =
+      reqConfig && reqConfig.formatter ? reqConfig.formatter : defaultFormatter;
     const request = fetch(url, opts);
     const response = await request;
     const body = await formatter(response);
@@ -65,6 +77,7 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
 
 interface RequestConfig {
   formatter?(response: Response): Promise<any>;
+  headers?: {[key: string]: string};
 }
 
 export class Client {


### PR DESCRIPTION
Hello,

I've been advised by the support team to follow the [MPZ guidelines](https://developers.procore.com/documentation/mpz-headers) however it seems it's not supported by the SDK.
If it's actually supported I'd be glad to close this PR and follow your advices.

I'm adding the MPZ support by allowing a user to add custom headers on the requests. Please let me know if it sounds legitimate to you and/or how I can improve this.

Cheers