### PR TITLE
AGX-302 Add companyId to RequestConfig, support custom headers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 3.0.2 (September 2022)
+
+* Add support for adding `Procore-Company-Id` request header when `companyId` is passed in `RequestConfig`.
+* Add support for customer headers.
+
 ## 3.0.1 (June 2021)
 
 * Adds support for Rest API versioning (rest/v1.0 is)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 3.0.2 (September 2022)
 
+* Add support for adding `Procore-Company-Id` request header when `defaultCompanyId` is passed in `ClientOptions`.
 * Add support for adding `Procore-Company-Id` request header when `companyId` is passed in `RequestConfig`.
 * Add support for customer headers.
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ the `@procore/js-sdk` will handle expanding them.
 An API version may be specified in the `version` attribute to the `client[method]`
 function call, or the `defaultVersion` is used. The default version is `v1.0` unless
 otherwise configured when instantiating the `client`
-(`client(Authorizer, RequestInit, { defaultVersion: 'vapid', companyId: 10 })`).
+(`client(Authorizer, RequestInit, { defaultVersion: 'vapid' })`).
 
 A company id may be specified in the `companyId` attribute to the `client[method]`
 function call, or the `defaultCompanyId` value will be used when appending the
 `Procore-Company-Id` header to the request.
-(`client(Authorizer, RequestInit, { defaultVersion: 'vapid', defaultCompanyId: 10 })`).
+(`client(Authorizer, RequestInit, { defaultCompanyId: 10 })`).
 
 
 | Example | Requested URL |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,13 @@ A single API response contains the response body (JSON parsed), original request
 
 ```javascript
 const procore = client(authorizer);
-procore.get({ base: '/projects', qs: { company_id: 1 } })
+procore.get({
+    base: '/projects',
+    qs: { company_id: 1 }
+  },
+  {
+    companyId: 1
+  })
   .then({ body, request, response } => {
     console.log(body[0].name); // ACME Construction LLC.
     console.log(response.headers.get('Total')) // 865 (Total records for the resource)
@@ -79,7 +85,13 @@ or
 const procore = client(authorizer);
 async function getProjects() {
   const { body, request, response } = await procore
-    .get({ base: '/projects', qs: { company_id: 1 } })
+    .get({
+      base: '/projects',
+      qs: { company_id: 1 }
+    },
+    {
+      companyId: 1
+    })
     .catch(error => {
     // Handle error
     console.log(error);
@@ -107,15 +119,15 @@ function formatter(response) {
 procore.get({base: '/me'}, { formatter })
 ```
 
-### Handling Multiple Procore Zones (MPZ)
+### Multiple Procore Zones (MPZ)
 
-You can also add custom headers to the request. A typical use case would be to add support for
-[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers)
+All requests to the Procore API must include the `Procore-Company-Id` header to support Multiple Procore Zones (MPZ). See
+[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers) for more details. A `Procore-Company-Id` header will automatically be added to the request if the `companyId` parameter is passed in the `RequestConfig` object.
 
 ```javascript
 const procore = client(authorizer);
 
-// Pass the headers configuration
+// Pass the companyId configuration in the RequestConfig
 procore.get(
   { base: "/projects" },
   { companyId: procoreCompanyId }

--- a/README.md
+++ b/README.md
@@ -114,13 +114,12 @@ You can also add custom headers to the request. A typical use case would be to a
 
 ```javascript
 const procore = client(authorizer);
-// Create your own headers
-const headers = {
-  'Procore-Company-Id': procoreCompanyId,
-};
 
 // Pass the headers configuration
-procore.get({base: '/projects', qs: {company_id: procoreCompanyId}, { headers })
+procore.get(
+  { base: "/projects" },
+  { companyId: procoreCompanyId }
+);
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -107,6 +107,22 @@ function formatter(response) {
 procore.get({base: '/me'}, { formatter })
 ```
 
+### Handling Multiple Procore Zones (MPZ)
+
+You can also add custom headers to the request. A typical use case would be to add support for
+[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers)
+
+```javascript
+const procore = client(authorizer);
+// Create your own headers
+const headers = {
+  'Procore-Company-Id': procoreCompanyId,
+};
+
+// Pass the headers configuration
+procore.get({base: '/projects', qs: {company_id: procoreCompanyId}, { headers })
+```
+
 ## Tests
 ```
 yarn && yarn test

--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ All paths are relative to `https://{apiHostname}/{vapid|rest/{version}}/`,
 the `@procore/js-sdk` will handle expanding them.
 
 An API version may be specified in the `version` attribute to the `client[method]`
-function call, or the default version is used. The default version is `v1.0` unless
+function call, or the `defaultVersion` is used. The default version is `v1.0` unless
 otherwise configured when instantiating the `client`
-(`client(Authorizer, RequestInit, { defaultVersion: 'vapid' })`).
+(`client(Authorizer, RequestInit, { defaultVersion: 'vapid', companyId: 10 })`).
+
+A company id may be specified in the `companyId` attribute to the `client[method]`
+function call, or the `defaultCompanyId` value will be used when appending the
+`Procore-Company-Id` header to the request.
+(`client(Authorizer, RequestInit, { defaultVersion: 'vapid', defaultCompanyId: 10 })`).
+
 
 | Example | Requested URL |
 | --- | --- |
@@ -122,7 +128,18 @@ procore.get({base: '/me'}, { formatter })
 ### Multiple Procore Zones (MPZ)
 
 All requests to the Procore API must include the `Procore-Company-Id` header to support Multiple Procore Zones (MPZ). See
-[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers) for more details. A `Procore-Company-Id` header will automatically be added to the request if the `companyId` parameter is passed in the `RequestConfig` object.
+[Multiple Procore Zones (MPZ)](https://developers.procore.com/documentation/mpz-headers) for more details. A `Procore-Company-Id` header will automatically be added to the request if the `defaultCompanyId` parameter is passed in the `ClientOptions` object or `companyId` parameter is passed in the `RequestConfig` object.
+
+```javascript
+// Pass the defaultCompanyId configuration in the ClientOptions
+const procore = client(authorizer, undefined, { defaultCompanyId: 10 });
+
+procore.get(
+  { base: "/projects" }
+);
+```
+
+or
 
 ```javascript
 const procore = client(authorizer);

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -35,15 +35,19 @@ function defaultFormatter(response: Response) {
   return Promise.resolve({});
 }
 
-const baseRequest = (defaults: RequestInit): Function => (url: string, config: RequestInit, reqConfig?: RequestConfig): Function => {
+const baseRequest = (defaults: RequestInit, options: ClientOptions): Function => (url: string, config: RequestInit, reqConfig?: RequestConfig): Function => {
   const headers = new Headers();
   headers.append('Accept', 'application/json');
   headers.append('Content-Type', 'application/json');
   headers.append('Procore-Sdk-Version', sdkVersionHeader);
   headers.append('Procore-Sdk-language', 'javascript');
+
   if (reqConfig?.companyId) {
     headers.append('Procore-Company-Id', `${reqConfig.companyId}`);
+  } else if (options?.defaultCompanyId) {
+    headers.append('Procore-Company-Id', `${options.defaultCompanyId}`);
   }
+
   if (config.headers) {
     if (config.headers instanceof Headers) {
       config.headers.forEach((value, name) => {
@@ -95,7 +99,7 @@ export class Client {
   constructor(authorizer: Authorizer, config: RequestInit = {}, options: ClientOptions) {
     this.authorize = authorizer.authorize;
     this.options = options;
-    this.request = baseRequest(config);
+    this.request = baseRequest(config, options);
   }
 
   public get = (endpoint: Endpoint, reqConfig?: RequestConfig): Promise<any> =>

--- a/lib/client.ts
+++ b/lib/client.ts
@@ -51,7 +51,19 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
       opts.headers[authKey] = authValue;
     }
 
-    const formatter = reqConfig && reqConfig.formatter ? reqConfig.formatter : defaultFormatter;
+    // Add custom headers if provided in RequestConfig
+    if (reqConfig && reqConfig.headers) {
+      Object.keys(reqConfig.headers).forEach((key) => {
+        if (opts.headers instanceof Headers) {
+          opts.headers.set(key, reqConfig.headers[key]);
+        } else {
+          opts.headers[key] = reqConfig.headers[key];
+        }
+      });
+    }
+
+    const formatter =
+      reqConfig && reqConfig.formatter ? reqConfig.formatter : defaultFormatter;
     const request = fetch(url, opts);
     const response = await request;
     const body = await formatter(response);
@@ -65,6 +77,7 @@ const baseRequest = (defaults: RequestInit): Function => (url: string, config: R
 
 interface RequestConfig {
   formatter?(response: Response): Promise<any>;
+  headers?: {[key: string]: string};
 }
 
 export class Client {

--- a/lib/clientOptions.ts
+++ b/lib/clientOptions.ts
@@ -6,6 +6,7 @@ const ClientOptionsDefaults: ClientOptions = {
 export interface ClientOptions {
   apiHostname?: string;
   defaultVersion?: string;
+  company_id?: number;
 }
 
 export function convert(options: ClientOptions | string): ClientOptions {

--- a/lib/clientOptions.ts
+++ b/lib/clientOptions.ts
@@ -6,7 +6,6 @@ const ClientOptionsDefaults: ClientOptions = {
 export interface ClientOptions {
   apiHostname?: string;
   defaultVersion?: string;
-  company_id?: number;
 }
 
 export function convert(options: ClientOptions | string): ClientOptions {

--- a/lib/clientOptions.ts
+++ b/lib/clientOptions.ts
@@ -6,6 +6,7 @@ const ClientOptionsDefaults: ClientOptions = {
 export interface ClientOptions {
   apiHostname?: string;
   defaultVersion?: string;
+  defaultCompanyId?: number | string;
 }
 
 export function convert(options: ClientOptions | string): ClientOptions {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A wrapper for the procore API",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -27,23 +27,23 @@
   "license": "MIT",
   "dependencies": {
     "isomorphic-fetch": "^3.0.0",
-    "qs": "^6.10.1"
+    "qs": "^6.10"
   },
   "devDependencies": {
-    "@types/chai": "^4.2.18",
+    "@types/chai": "^4.3",
     "@types/core-js": "^2.5.4",
-    "@types/fetch-mock": "^7.3.3",
+    "@types/fetch-mock": "^7.3",
     "@types/isomorphic-fetch": "^0.0.35",
     "@types/mocha": "^8.2.2",
     "@types/qs": "^6.9.6",
     "@types/sinon": "^9.0.11",
-    "chai": "^4.3.4",
+    "chai": "^4.3",
     "fetch-mock": "^9.11.0",
     "jsdom": "^16.6.0",
     "mocha": "^8.3.2",
     "rimraf": "^3.0.2",
     "sinon": "^10.0.0",
     "ts-node": "^9.1.1",
-    "typescript": "^4.3.2"
+    "typescript": "^4.6"
   }
 }

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -17,6 +17,10 @@ const headers = {
 };
 
 describe('client', () => {
+  beforeEach(() => {
+    fetchMock.reset();
+  });
+
   context('Override fetch', () => {
     it('uses a custom formatter', async () => {
       const authorizer = oauth(token);
@@ -37,12 +41,39 @@ describe('client', () => {
       fetchMock.restore();
     });
 
+    it('sets company id header', async () => {
+      const authorizer = oauth(token);
+      const procore = client(authorizer, { headers: { ...headers } });
+
+      const customHeaders = {
+        'Procore-Company-Id': `${company.id}`,
+      };
+
+      fetchMock.get(
+        {
+          url: `${hostname}/foo/projects`,
+          headers: {
+            ...headers,
+            ...customHeaders,
+          },
+        },
+        project
+      );
+
+      const { body } = await procore.get('/foo/projects', {
+        companyId: company.id
+      });
+
+      expect(body).to.eql(project);
+      fetchMock.restore();
+    });
+
     it('uses a custom header', async () => {
       const authorizer = oauth(token);
       const procore = client(authorizer, { headers: { ...headers } });
 
       const customHeaders = {
-        'Procore-Company-Id': company.id,
+        'Procore-Company-Id': `${company.id}`,
       };
 
       fetchMock.get(

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -41,9 +41,61 @@ describe('client', () => {
       fetchMock.restore();
     });
 
-    it('sets company id header', async () => {
+    it('sets company id header using clientOptions', async () => {
+      const authorizer = oauth(token);
+      const procore = client(authorizer, { headers: { ...headers } }, { defaultCompanyId: company.id });
+
+      const customHeaders = {
+        'Procore-Company-Id': `${company.id}`,
+      };
+
+      fetchMock.get(
+        {
+          url: `${hostname}/foo/projects`,
+          headers: {
+            ...headers,
+            ...customHeaders,
+          },
+        },
+        project
+      );
+
+      const { body } = await procore.get('/foo/projects');
+
+      expect(body).to.eql(project);
+      fetchMock.restore();
+    });
+
+    it('sets company id header using requestConfig', async () => {
       const authorizer = oauth(token);
       const procore = client(authorizer, { headers: { ...headers } });
+
+      const customHeaders = {
+        'Procore-Company-Id': `${company.id}`,
+      };
+
+      fetchMock.get(
+        {
+          url: `${hostname}/foo/projects`,
+          headers: {
+            ...headers,
+            ...customHeaders,
+          },
+        },
+        project
+      );
+
+      const { body } = await procore.get('/foo/projects', {
+        companyId: company.id
+      });
+
+      expect(body).to.eql(project);
+      fetchMock.restore();
+    });
+
+    it('sets company id header using requestConfig with different clientOptions', async () => {
+      const authorizer = oauth(token);
+      const procore = client(authorizer, { headers: { ...headers } }, { defaultCompanyId: 6765 });
 
       const customHeaders = {
         'Procore-Company-Id': `${company.id}`,

--- a/test/client.spec.ts
+++ b/test/client.spec.ts
@@ -243,7 +243,7 @@ describe('client', () => {
 
       it('creates a resource', async () => {
         fetchMock.post(
-            { url: `${hostname}/rest/v1.0/projects/${project.id}/rfis`, headers: headers }, rfi);
+          { url: `${hostname}/rest/v1.0/projects/${project.id}/rfis`, headers: headers }, rfi);
 
         const { body } = await procore
           .post({
@@ -259,7 +259,7 @@ describe('client', () => {
         fetchMock.post(
           { url: `${hostname}/rest/v1.0/projects/${project.id}/rfis`, headers: headers }, (url, opts: RequestInit) => {
             return opts.body;
-        });
+          });
 
         const { body } = await procore
           .post({
@@ -381,7 +381,7 @@ describe('client', () => {
         fetchMock.delete(
           { url: `${hostname}/rest/v1.0/projects/${project.id}/rfis/${rfi.id}`, headers: headers }, (url, opts: RequestInit) => {
             return { body: opts.body, status: 200 };
-        });
+          });
 
         const { body } = await procore
           .delete({

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,20 +236,20 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/chai@^4.2.18":
-  version "4.2.18"
-  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
-  integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
+"@types/chai@^4.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.3.tgz#3c90752792660c4b562ad73b3fbd68bf3bc7ae07"
+  integrity sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==
 
 "@types/core-js@^2.5.4":
   version "2.5.4"
   resolved "https://registry.yarnpkg.com/@types/core-js/-/core-js-2.5.4.tgz#fc42ebde7d9cfa7c5f2668f117449b02348e41fd"
   integrity sha512-Xwy8o12ak+iYgFr/KCVaVK5Sy+jFMiiPAID3+ObvMlBzy26XQJw5xu+a6rlHsrJENXj/AwJOGsJpVohUjAzSKQ==
 
-"@types/fetch-mock@^7.3.3":
-  version "7.3.3"
-  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.3.tgz#255511d70087b9ae8866704c782c88cc96a0b45b"
-  integrity sha512-NLMbBVQh3yx6dMd5CnVxp9ZBhQYuFzWIlRk0kQbgBfyL75u3wtZyUTuFsK9Wb9G3eIw77yja858j1fQAWqM9Og==
+"@types/fetch-mock@^7.3":
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.5.tgz#7aee678c4e7c7e1a168bae8fdab5b8d712e377f6"
+  integrity sha512-sLecm9ohBdGIpYUP9rWk5/XIKY2xHMYTBJIcJuBBM8IJWnYoQ1DAj8F4OVjnfD0API1drlkWEV0LPNk+ACuhsg==
 
 "@types/isomorphic-fetch@^0.0.35":
   version "0.0.35"
@@ -444,15 +444,16 @@ caniuse-lite@^1.0.30001181:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001204.tgz#256c85709a348ec4d175e847a3b515c66e79f2aa"
   integrity sha512-JUdjWpcxfJ9IPamy2f5JaRDCaqJOxDzOSKtbdx4rH9VivMd1vIzoPumsJa9LoMIi4Fx2BV2KZOxWhNkBjaYivQ==
 
-chai@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
-  integrity sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==
+chai@^4.3:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.6.tgz#ffe4ba2d9fa9d6680cc0b370adae709ec9011e9c"
+  integrity sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==
   dependencies:
     assertion-error "^1.1.0"
     check-error "^1.0.2"
     deep-eql "^3.0.1"
     get-func-name "^2.0.0"
+    loupe "^2.3.1"
     pathval "^1.1.1"
     type-detect "^4.0.5"
 
@@ -1054,6 +1055,13 @@ log-symbols@4.0.0:
   dependencies:
     chalk "^4.0.0"
 
+loupe@^2.3.1:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.4.tgz#7e0b9bffc76f148f9be769cb1321d3dcf3cb25f3"
+  integrity sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==
+  dependencies:
+    get-func-name "^2.0.0"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -1250,10 +1258,10 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.10.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.1.tgz#4931482fa8d647a5aab799c5271d2133b981fb6a"
-  integrity sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==
+qs@^6.10:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 
@@ -1487,10 +1495,10 @@ type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@^4.6:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
+  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
 universalify@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Adds support for Multiple Procore Zones by adding companyId to the RequestConfig interface and propagating its value into the correct header.

Includes code from https://github.com/procore/js-sdk/pull/49 