### PR TITLE
DEVPROD-98/ecosystem-division

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Read more about CODEOWNERS here - https://github.com/blog/2392-introducing-code-owners
+# how to setup: https://procoretech.atlassian.net/wiki/spaces/DEV/pages/366805250/Github+how+to+setup+CODEOWNERS
+
+*   @procore/team-api

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,6 +3,7 @@ kind: Component
 metadata:
   name: js-sdk
   description: A node.js JS SDK for the Procore API. NPM package @procore/js-sdk
+  title: Procore JS SDK
   annotations:
     github.com/project-slug: procore/js-sdk
     github.com/team-slug: procore/team-api


### PR DESCRIPTION
Adding title for js-sdk in Backstage to follow the pattern for Ruby SDKs