### PR TITLE
Release 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ const { body } = await procore.get({
   base: '/vapid/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 }
 });
-// api.procore.com/vapid/drawing_areas/42/drawings
+// app.procore.com/vapid/drawing_areas/42/drawings
 ```
 
 v3.0.1 Version Usage
@@ -72,21 +72,21 @@ const { body } = await procore.get({
   base: '/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 }
 });
-// api.procore.com/rest/v1.0/drawing_areas/42/drawings
+// app.procore.com/rest/v1.0/drawing_areas/42/drawings
 
 // Override default version
 const { body } = await procore.get({ 
   base: '/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 },
   version: 'v1.1' });
-// api.procore.com/rest/v1.1/drawing_areas/42/drawings
+// app.procore.com/rest/v1.1/drawing_areas/42/drawings
 
 // Override default version with legacy version
 const { body } = await procore.get({
   base: '/drawing_areas/{drawing_area_id}/drawings',
   params: { drawing_area_id: 42 },
   version: 'vapid' });
-// api.procore.com/vapid/drawing_areas/42/drawings
+// app.procore.com/vapid/drawing_areas/42/drawings
 ```
 
 To keep the legacy behavior, set the new `defaultVersion` configuration option when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 4.1.0 (November 2023)
+
+* Change hostname url from `app` to `api`
+
 ## 4.0.2 (March 2023)
 
 * Improve Csrf Class (No change in functionality)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.1.0 (November 2023)
 
-* Change hostname url from `app` to `api`
+* Update codes to be consistent of API hostname `api.procore.com`
 
 ## 4.0.2 (March 2023)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@procore/js-sdk",
-  "version": "4.0.2",
+  "version": "4.1.0",
   "description": "A wrapper for the procore API",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
- version and change log for 4.1.0 release 
  - https://github.com/procore/js-sdk/compare/c3da93213888f00b94c6a38ba59d3a0d6fa60f7f...a6ebd98337ad8e5f6c83602b1df4321bd538ce47  
- revert readme changes for older versions

---
Local publish test with yalc:

```
➜  js-sdk git:(release-4-1-0) ✗ yarn compile
yarn run v1.22.19
$ yarn writeVer && tsc
$ cp package.json lib/version.json
✨  Done in 4.55s.
➜  js-sdk git:(release-4-1-0) ✗ yalc publish --files
Files included in published content:
- dist/authorize.js
- dist/client.js
- dist/clientOptions.js
- dist/csrf.js
- dist/implicit.js
- dist/index.js
- dist/info.js
- dist/interfaces.js
- dist/oauth.js
- dist/refresh.js
- dist/refresher.js
- dist/revoke.js
- dist/sdkVersion.js
- dist/token.js
- package.json
- dist/version.json
- README.md
- dist/types/authorize.d.ts
- dist/types/client.d.ts
- dist/types/clientOptions.d.ts
- dist/types/csrf.d.ts
- dist/types/implicit.d.ts
- dist/types/index.d.ts
- dist/types/info.d.ts
- dist/types/interfaces.d.ts
- dist/types/oauth.d.ts
- dist/types/refresh.d.ts
- dist/types/refresher.d.ts
- dist/types/revoke.d.ts
- dist/types/sdkVersion.d.ts
- dist/types/token.d.ts
- LICENSE.txt
Total 32 files.
@procore/js-sdk@4.1.0 published in store.
```
Previous CI publish https://app.circleci.com/pipelines/github/procore/js-sdk/141/workflows/054e4edb-8d9d-4da1-8a8c-fe9101d1bda7/jobs/299